### PR TITLE
Finish up protected packages. Maps now respect protected packages in

### DIFF
--- a/src/main/java/net/md_5/specialsource/JarMapping.java
+++ b/src/main/java/net/md_5/specialsource/JarMapping.java
@@ -75,13 +75,14 @@ public class JarMapping {
      * Add a class name prefix to the mapping ignore list.
      * Note: this only applies before loading mappings, not after
      */
-    public void addIgnorePackage(String packageName) {
+    public void addProtectedPackage(String packageName) {
+        SpecialSource.log("Protecting Package: " + packageName);
         ignoredPackages.add(packageName);
     }
 
-    private boolean isClassIgnored(String className) {
+    private boolean isProtectedPackage(String desc) {
         for (String packageName : ignoredPackages) {
-            if (className.startsWith(packageName)) {
+            if (desc.startsWith(packageName)) {
                 return true;
             }
         }
@@ -153,7 +154,7 @@ public class JarMapping {
         }
 
         if (srgFiles.size() == 0) {
-            throw new IOException("loadMappingsDir(" + dirname + "): no joined.srg, client.srg, or client.srg found");
+            throw new IOException("loadMappingsDir(" + dirname + "): no joined.srg, client.srg, or server.srg found");
         }
 
         // Read output names through csv mappings, if available & enabled
@@ -324,7 +325,8 @@ public class JarMapping {
                 oldClassName = temp;
             }
 
-            if (isClassIgnored(oldClassName)) {
+            if (isProtectedPackage(oldClassName)) {
+                SpecialSource.log("Ignored CL: " + oldClassName + " " + newClassName);
                 return;
             }
 
@@ -350,6 +352,11 @@ public class JarMapping {
                 String temp = newPackageName;
                 newPackageName = oldPackageName;
                 oldPackageName = temp;
+            }
+
+            if (isProtectedPackage(oldPackageName)) {
+                SpecialSource.log("Ignored PK: " + oldPackageName + " -> " + newPackageName);
+                return;
             }
 
             // package names always either 1) suffixed with '/', or 2) equal to '.' to signify default package
@@ -392,6 +399,11 @@ public class JarMapping {
                 oldFieldName = temp;
             }
 
+            if (isProtectedPackage(oldClassName)) {
+                SpecialSource.log("Ignored FD: " + oldClassName + "/" + oldFieldName + " -> " +  newFieldName);
+                return;
+            }
+
             fields.put(oldClassName + "/" + oldFieldName, newFieldName);
         } else if (kind.equals("MD:")) {
             String oldFull = tokens[1];
@@ -420,6 +432,11 @@ public class JarMapping {
                 String temp = newMethodName;
                 newMethodName = oldMethodName;
                 oldMethodName = temp;
+            }
+
+            if (isProtectedPackage(oldClassName)) {
+                SpecialSource.log("Ignored MD: " + oldClassName + "/" + oldMethodName + " -> " +  newMethodName);
+                return;
             }
 
             methods.put(oldClassName + "/" + oldMethodName + " " + oldMethodDescriptor, newMethodName);

--- a/src/main/java/net/md_5/specialsource/SpecialSource.java
+++ b/src/main/java/net/md_5/specialsource/SpecialSource.java
@@ -121,6 +121,9 @@ public class SpecialSource {
                 acceptsAll(asList("d", "identifier"), "Identifier to place on each class that is transformed, by default, none")
                         .withRequiredArg()
                         .ofType(String.class);
+                acceptsAll(asList("p", "ignored-packages"), "A comma seperated list of packages that should not be transformed, even if the srg specifies they should")
+                        .withRequiredArg()
+                        .ofType(String.class);
             }
         };
 
@@ -159,6 +162,12 @@ public class SpecialSource {
             identifier = (String)options.valueOf("identifier");
         }
 
+        String[] ignored = new String[0];
+        if (options.has("ignored-packages"))
+        {
+            ignored = ((String)options.valueOf("ignored-packages")).split(",");
+        }
+
         FileLocator.useCache = !options.has("force-redownload");
 
         if (options.has("first-jar") && options.has("second-jar")) {
@@ -173,10 +182,18 @@ public class SpecialSource {
             visit(new Pair<Jar>(jar1, jar2), new Pair<JarComparer>(visitor1, visitor2), new Pair<String>(jar1.getMain(), jar2.getMain()));
 
             jarMapping = new JarMapping(visitor1, visitor2, (File) options.valueOf("srg-out"), options.has("compact"), options.has("generate-dupes"));
+            for (String pkg : ignored)
+            {
+                jarMapping.addProtectedPackage(pkg);
+            }
         } else if (options.has("srg-in")) {
             log("Loading mappings");
 
             jarMapping = new JarMapping();
+            for (String pkg : ignored)
+            {
+                jarMapping.addProtectedPackage(pkg);
+            }
 
             // Loading options
             boolean reverse = options.has("reverse");
@@ -253,7 +270,7 @@ public class SpecialSource {
         }
     }
 
-    private static void log(String message) {
+    public static void log(String message) {
         if (options != null && !options.has("quiet")) {
             System.out.println(message);
         }


### PR DESCRIPTION
method invocations and signatures.
New argument -p, --ignored-packages to specify protected

It seems to produce properly obfed jars as you would expect:

before

```
public static bbe a(JsonNode par0JsonNode)
{
    bbe mcoserver = new bbe();
    try
    {
    mcoserver.a = Long.parseLong(par0JsonNode.c(new Object[] { "id" }));
    mcoserver.b = par0JsonNode.b(new Object[] { "name" });
    mcoserver.c = par0JsonNode.b(new Object[] { "motd" });
    mcoserver.d = par0JsonNode.b(new Object[] { "state" });
    mcoserver.e = par0JsonNode.b(new Object[] { "owner" });

    if (par0JsonNode.d(new Object[] { "invited" }))
    {
        mcoserver.f = a(par0JsonNode.e(new Object[] { "invited" }));
    }
    else
    {
        mcoserver.f = new ArrayList();
    }

    mcoserver.i = Integer.parseInt(par0JsonNode.c(new Object[] { "daysLeft" }));
    mcoserver.g = par0JsonNode.b(new Object[] { "ip" });
    mcoserver.h = par0JsonNode.a(new Object[] { "expired" }).booleanValue();
    }
    catch (IllegalArgumentException illegalargumentexception)
    {
    }

    return mcoserver;
}
```

after:

```
public static bbe a(JsonNode par0JsonNode)
{
    bbe mcoserver = new bbe();
    try
    {
        mcoserver.a = Long.parseLong(par0JsonNode.getNumberValue(new Object[] { "id" }));
        mcoserver.b = par0JsonNode.getStringValue(new Object[] { "name" });
        mcoserver.c = par0JsonNode.getStringValue(new Object[] { "motd" });
        mcoserver.d = par0JsonNode.getStringValue(new Object[] { "state" });
        mcoserver.e = par0JsonNode.getStringValue(new Object[] { "owner" });

        if (par0JsonNode.isArrayNode(new Object[] { "invited" }))
        {
            mcoserver.f = a(par0JsonNode.getArrayNode(new Object[] { "invited" }));
        }
        else
        {
            mcoserver.f = new ArrayList();
        }

        mcoserver.i = Integer.parseInt(par0JsonNode.getNumberValue(new Object[] { "daysLeft" }));
        mcoserver.g = par0JsonNode.getStringValue(new Object[] { "ip" });
        mcoserver.h = par0JsonNode.getBooleanValue(new Object[] { "expired" }).booleanValue();
    }
    catch (IllegalArgumentException illegalargumentexception)
    {
    }

    return mcoserver;
}
```
