### PR TITLE
Update AccessMap.java

### DIFF
--- a/src/main/java/net/md_5/specialsource/AccessMap.java
+++ b/src/main/java/net/md_5/specialsource/AccessMap.java
@@ -72,10 +72,9 @@ public class AccessMap {
             if (n != -1) {
                 line = line.substring(0, n);
             }
-            n = line.lastIndexOf(' ');
-            if (n != -1) {
-                line = line.substring(0, n);
-            }
+            
+            n = n.trim()
+            
             if (line.isEmpty()) {
                 continue;
             }


### PR DESCRIPTION
in cases where the AT (badly written ones atleast) contain lines like this

```
public ber.c#ThreadDownloadImageData field_110315_c
public ber.e#ResourceLocation field_110313_e
```

the old code would grab the last space character, and this only grab 'public' as the line.

Ofcourse using trim would also eat leading white space, but I don't think thats an issue. Not to mention, the old implementation would only trim 1 space off the end of the line, and not any others if they exist.
