### PR TITLE
Merging two AccessChanges should merge their visibility.

### DIFF
--- a/src/main/java/net/md_5/specialsource/AccessChange.java
+++ b/src/main/java/net/md_5/specialsource/AccessChange.java
@@ -160,6 +160,9 @@ public class AccessChange {
             set &= ~MASK_ALL_VISIBILITY;
         }
 
+        // Merge visibility changes
+        vis = upgradeVisibility(vis, rhs.vis);
+
         set |= rhs.set;
     }
 


### PR DESCRIPTION
Previously a merge would ignore visibility changes entirely, now it merges them as in apply.

It looks like this was forgotten in 0f3edc778edb4765a0a5931baf23e4999c9f8267.
