### PR TITLE
Don't overwrite existing AccessChange when adding duplicate.

### DIFF
--- a/src/main/java/net/md_5/specialsource/AccessMap.java
+++ b/src/main/java/net/md_5/specialsource/AccessMap.java
@@ -142,7 +142,9 @@ public class AccessMap {
             System.out.println("INFO: merging AccessMap " + key + " from " + map.get(key) + " with " + accessChange);
             map.get(key).merge(accessChange);
         }
-        map.put(key, accessChange);
+        else {
+            map.put(key, accessChange);
+        }
     }
 
     public int applyClassAccess(String className, int access) {


### PR DESCRIPTION
This made the call to merge completely pointless.

Noticed by @skyboy in Forge IRC.
