### PR TITLE
Update asm to 5.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-debug-all</artifactId>
-            <version>4.1</version>
+            <version>5.0.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
so java 8 classes can be read properly instead of returning null