### PR TITLE
Fix incorrect srg-out destination

### DIFF
--- a/src/main/java/net/md_5/specialsource/JarMapping.java
+++ b/src/main/java/net/md_5/specialsource/JarMapping.java
@@ -597,7 +597,7 @@ public class JarMapping {
             }
         }
 
-        try (PrintWriter out = (logfile != null ? new PrintWriter(System.out) : new PrintWriter(logfile))) {
+        try (PrintWriter out = (logfile == null ? new PrintWriter(System.out) : new PrintWriter(logfile))) {
             srgWriter.write(out);
         }
     }


### PR DESCRIPTION
`System.out` will be written to when `--srg-out` is provided,
and `logfile` (i.e. null) will be written to when `--srg-out` is not provided.