### PR TITLE
Create output directory if it does not exist.

### DIFF
--- a/src/main/java/net/md_5/specialsource/JarRemapper.java
+++ b/src/main/java/net/md_5/specialsource/JarRemapper.java
@@ -172,6 +172,9 @@ public class JarRemapper extends CustomRemapper {
         if (jar == null) {
             return;
         }
+        if (!target.getParentFile().exists()) {
+            target.getParentFile().mkdirs();
+        }
         ClassRepo repo = new JarRepo(jar);
         try (JarOutputStream out = new JarOutputStream(new FileOutputStream(target))) {
             Set<String> jarEntries = jar.getEntryNames();


### PR DESCRIPTION
FileOutputStreams will not automatically create the necessary directories, so we have to do it.