### PR TITLE
Fixed null pointer exception with relative paths

### DIFF
--- a/src/main/java/net/md_5/specialsource/JarRemapper.java
+++ b/src/main/java/net/md_5/specialsource/JarRemapper.java
@@ -176,7 +176,7 @@ public class JarRemapper extends CustomRemapper {
         if (jar == null) {
             return;
         }
-        if (!target.getParentFile().exists()) {
+        if (target != null && target.getParentFile() != null && !target.getParentFile().exists()) {
             target.getParentFile().mkdirs();
         }
         ClassRepo repo = new JarRepo(jar);


### PR DESCRIPTION
Fixed null pointer exception when using relative paths and the output jar directory is the same as the working directory.