### PR TITLE
Update source to 1.8 and add support for loading an InputStream as mappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     </issueManagement>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -136,6 +136,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -137,14 +137,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/net/md_5/specialsource/JarMapping.java
+++ b/src/main/java/net/md_5/specialsource/JarMapping.java
@@ -194,7 +194,11 @@ public class JarMapping {
     }
 
     public void loadMappings(File file) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+        loadMappings(new FileInputStream(file));
+    }
+
+    public void loadMappings(InputStream stream) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
             loadMappings(reader, null, null, false);
         }
     }


### PR DESCRIPTION
The source file JarMapping.java has the following snippet:
`Remapper reverseMapper = new Remapper() {
            @Override
            public String map(String cls) {
                return clsMap.getOrDefault(cls, cls);
            }
        };`
Referencing the Javadocs (https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#getOrDefault-java.lang.Object-V-), you can see that this method is marked 1.8+. This is also reflected in the JavaSE 7 Javadocs where the method isn't found (https://docs.oracle.com/javase/7/docs/api/java/util/Map.html).

Since Spigot requires Java 8 anyways, there is no reason to stay behind on Java 7.

I also added support for loading mappings via InputStream and File. This allows mappings to be loaded from a URL/URI.