### PR TITLE
Support TSRGv2

### DIFF
--- a/src/main/java/net/md_5/specialsource/JarMapping.java
+++ b/src/main/java/net/md_5/specialsource/JarMapping.java
@@ -305,6 +305,9 @@ public class JarMapping {
         };
 
         for (String l : lines) {
+            if (l.startsWith("tsrg2")) {
+                continue;
+            }
             if (l.contains(":")) {
                 // standard srg
                 parseSrgLine(l, inputTransformer, outputTransformer, reverse);
@@ -323,6 +326,10 @@ public class JarMapping {
      */
     private void parseCsrgLine(String line, MappingTransformer inputTransformer, MappingTransformer outputTransformer, boolean reverse, Remapper reverseMap) throws IOException {
         //Tsrg format, identical to Csrg, except the field and method lines start with \t and should use the last class the was parsed.
+        if (line.startsWith("\t\t")) {
+            // Two tabs means the format is Tsrgv2 with parameters and extra data that isn't needed.
+            return;
+        }
         if (line.startsWith("\t")) {
             if (this.currentClass == null) {
                 throw new IOException("Invalid tsrg file, tsrg field/method line before class line: " + line);


### PR DESCRIPTION
This is a simple PR that prevents SpecialSource from crashing when parsing a TSRGv2 file. TSRGv2 has extra data about methods like parameters and whether it is static, but this data is not important to use SpecialSource, so it simply returns early when parsing lines with double tabs. TSRGv2 files also container a header line at the start, which is also filtered out.