### PR TITLE
Allow remapping Class#getDeclaredField

### DIFF
--- a/src/main/java/net/md_5/specialsource/JarMapping.java
+++ b/src/main/java/net/md_5/specialsource/JarMapping.java
@@ -50,7 +50,7 @@ public class JarMapping {
 
     public final LinkedHashMap<String, String> packages = new LinkedHashMap<String, String>();
     public final Map<String, String> classes = new HashMap<String, String>();
-    public final Map<String, String> fields = new HashMap<String, String>();
+    public final SortedMap<String, String> fields = new TreeMap<String, String>();
     public final Map<String, String> methods = new HashMap<String, String>();
     private InheritanceMap inheritanceMap = new InheritanceMap();
     private InheritanceProvider fallbackInheritanceProvider = null;

--- a/src/main/java/net/md_5/specialsource/SpecialSource.java
+++ b/src/main/java/net/md_5/specialsource/SpecialSource.java
@@ -284,7 +284,7 @@ public class SpecialSource {
         if (options.has("access-transformer")) {
             access = new AccessMap();
             access.loadAccessTransformer((File) options.valueOf("access-transformer"));
-            accessMapper = new RemapperProcessor(null, jarMapping, access);
+            accessMapper = new RemapperProcessor(null, null, access);
         }
 
         if (options.has("in-jar") && options.has("out-jar")) {

--- a/src/main/java/net/md_5/specialsource/SpecialSource.java
+++ b/src/main/java/net/md_5/specialsource/SpecialSource.java
@@ -116,7 +116,7 @@ public class SpecialSource {
                         .withRequiredArg()
                         .ofType(String.class);
 
-                //acceptsAll(asList("G", "remap-reflect-field"), "Remap reflection calls to getDeclaredField()"); // TODO
+                acceptsAll(asList("G", "remap-reflect-field"), "Remap reflection calls to getDeclaredField()");
 
                 acceptsAll(asList("q", "quiet"), "Quiet mode");
                 acceptsAll(asList("progress-interval"),"% markers at which to print progress")
@@ -274,6 +274,11 @@ public class SpecialSource {
             inheritanceProviders.add(inheritanceMap);
         }
 
+        RemapperProcessor reflectionMapper = null;
+        if (options.has("remap-reflect-field")) {
+            reflectionMapper = new RemapperProcessor(null, jarMapping, null);
+        }
+
         RemapperProcessor accessMapper = null;
         AccessMap access = null;
         if (options.has("access-transformer")) {
@@ -295,7 +300,7 @@ public class SpecialSource {
             inheritanceProviders.add(new JarProvider(jar3));
 
             log("Remapping final jar");
-            JarRemapper jarRemapper = new JarRemapper(null, jarMapping, accessMapper);
+            JarRemapper jarRemapper = new JarRemapper(reflectionMapper, jarMapping, accessMapper);
             if (options.has("log")) {
                 File logOutput = (File) options.valueOf("log");
                 jarRemapper.setLogFile(logOutput);


### PR DESCRIPTION
* Enabled `remap-reflect-field` flag
* Fixed access transformer enabling reflection remapping
  * The AT remapper is a postprocessor running after the main remap is done. As a result, the class names used to look up reflection are the remapped class names, not the original, resulting in at best no matches and at worst incorrect matches.
* Fixed not being able to remap reflective access of fields from Proguard mappings
  * Converted `JarMapping.fields` to a SortedMap to make searching mappings to ignore description less intensive

This appears to work well, but my use case is a single field (which is also why I was so slow to bother submitting a PR) so I have not done particularly extensive testing. I don't know if using a SortedMap is actually necessary for performance, but I figured searching all 29k fields from vanilla for every single call in reflection-heavy projects would be a Bad Idea™.

Closes #87 